### PR TITLE
Navigation improvments

### DIFF
--- a/content/en/LCNC-SEC-01-Account-Impersonation.md
+++ b/content/en/LCNC-SEC-01-Account-Impersonation.md
@@ -1,4 +1,9 @@
-# LCNC-SEC-01: Account Impersonation
+---
+
+layout: col-sidebar
+title: "LCNC-SEC-01: Account Impersonation"
+
+---
 
 ## Risk Rating [*](https://owasp.org/www-project-top-ten/2017/Note_About_Risks)
 

--- a/content/en/LCNC-SEC-02-Authorization-Misuse.md
+++ b/content/en/LCNC-SEC-02-Authorization-Misuse.md
@@ -1,4 +1,9 @@
-# LCNC-SEC-02: Authorization Misuse
+---
+
+layout: col-sidebar
+title: "LCNC-SEC-02: Authorization Misuse"
+
+---
 
 ## Risk Rating [*](https://owasp.org/www-project-top-ten/2017/Note_About_Risks)
 

--- a/content/en/LCNC-SEC-03-Data-Leakage-and-Unexpected-Consequences.md
+++ b/content/en/LCNC-SEC-03-Data-Leakage-and-Unexpected-Consequences.md
@@ -1,4 +1,9 @@
-# LCNC-SEC-03: Data Leakage and Unexpected Consequences
+---
+
+layout: col-sidebar
+title: "LCNC-SEC-03: Data Leakage and Unexpected Consequences"
+
+---
 
 ## Risk Rating [*](https://owasp.org/www-project-top-ten/2017/Note_About_Risks)
 

--- a/content/en/LCNC-SEC-04-Authentication-and-Secure-Communication-Failures.md
+++ b/content/en/LCNC-SEC-04-Authentication-and-Secure-Communication-Failures.md
@@ -1,4 +1,9 @@
-# LCNC-SEC-04: Authentication and Secure Communication Failures
+---
+
+layout: col-sidebar
+title: "LCNC-SEC-04: Authentication and Secure Communication Failures"
+
+---
 
 ## Risk Rating [*](https://owasp.org/www-project-top-ten/2017/Note_About_Risks)
 

--- a/content/en/LCNC-SEC-05-Security-Misconfiguration.md
+++ b/content/en/LCNC-SEC-05-Security-Misconfiguration.md
@@ -1,4 +1,9 @@
-# LCNC-SEC-05: Security Misconfiguration
+---
+
+layout: col-sidebar
+title: "LCNC-SEC-05: Security Misconfiguration"
+
+---
 
 ## Risk Rating [*](https://owasp.org/www-project-top-ten/2017/Note_About_Risks)
 

--- a/content/en/LCNC-SEC-06-Injection-Handling-Failures.md
+++ b/content/en/LCNC-SEC-06-Injection-Handling-Failures.md
@@ -1,4 +1,9 @@
-# LCNC-SEC-06: Injection Handling Failures
+---
+
+layout: col-sidebar
+title: "LCNC-SEC-06: Injection Handling Failures"
+
+---
 
 ## Risk Rating [*](https://owasp.org/www-project-top-ten/2017/Note_About_Risks)
 

--- a/content/en/LCNC-SEC-07-Vulnerable-and-Untrusted-Components.md
+++ b/content/en/LCNC-SEC-07-Vulnerable-and-Untrusted-Components.md
@@ -1,4 +1,9 @@
-# LCNC-SEC-07: Vulnerable and Untrusted Components
+---
+
+layout: col-sidebar
+title: "LCNC-SEC-07: Vulnerable and Untrusted Components"
+
+---
 
 ## Risk Rating [*](https://owasp.org/www-project-top-ten/2017/Note_About_Risks)
 

--- a/content/en/LCNC-SEC-08-Data-and-Secret-Handling-Failures.md
+++ b/content/en/LCNC-SEC-08-Data-and-Secret-Handling-Failures.md
@@ -1,4 +1,9 @@
-# LCNC-SEC-08: Data and Secret Handling Failures
+---
+
+layout: col-sidebar
+title: "LCNC-SEC-08: Data and Secret Handling Failures"
+
+---
 
 ## Risk Rating [*](https://owasp.org/www-project-top-ten/2017/Note_About_Risks)
 

--- a/content/en/LCNC-SEC-09-Asset-Management-Failures.md
+++ b/content/en/LCNC-SEC-09-Asset-Management-Failures.md
@@ -1,4 +1,9 @@
-# LCNC-SEC-09: Asset Management Failures
+---
+
+layout: col-sidebar
+title: "LCNC-SEC-09: Asset Management Failures"
+
+---
 
 ## Risk Rating [*](https://owasp.org/www-project-top-ten/2017/Note_About_Risks)
 

--- a/content/en/LCNC-SEC-10-Security-Logging-and-Monitoring-Failures.md
+++ b/content/en/LCNC-SEC-10-Security-Logging-and-Monitoring-Failures.md
@@ -1,4 +1,9 @@
-# LCNC-SEC-10: Security Logging and Monitoring Failures
+---
+
+layout: col-sidebar
+title: "LCNC-SEC-10: Security Logging and Monitoring Failures"
+
+---
 
 ## Risk Rating [*](https://owasp.org/www-project-top-ten/2017/Note_About_Risks)
 

--- a/content/en/Risk-Template.md
+++ b/content/en/Risk-Template.md
@@ -1,4 +1,9 @@
-# LCNC-SEC-XX: TITLE
+---
+
+layout: col-sidebar
+title: "LCNC-SEC-XX: TITLE"
+
+---
 
 ## Risk Rating [*](https://owasp.org/www-project-top-ten/2017/Note_About_Risks)
 

--- a/content/en/info.md
+++ b/content/en/info.md
@@ -1,19 +1,3 @@
-### Project Classification
-
-![Documentation Project][doc-proj-logo]
-
-[![Builders][builders-logo]][builders]
-[![Breakers][breakers-logo]][breakers]
-[![Defenders][defenders-logo]][defenders]
-
-[builders]: https://www.owasp.org/index.php/Builders
-[builders-logo]: https://raw.githubusercontent.com/OWASP/www--site-theme/master/assets/images/common/owasp_builders.svg?sanitize=true
-[breakers]: https://www.owasp.org/index.php/Breakers
-[breakers-logo]: https://raw.githubusercontent.com/OWASP/www--site-theme/master/assets/images/common/owasp_breakers.svg?sanitize=true
-[defenders]: https://www.owasp.org/index.php/Defenders
-[defenders-logo]: https://raw.githubusercontent.com/OWASP/www--site-theme/master/assets/images/common/owasp_defenders.svg?sanitize=true
-[doc-proj-logo]: https://raw.githubusercontent.com/OWASP/www--site-theme/master/assets/images/common/owasp_documentation_project.svg?sanitize=true
-
 
 ### Top 10 Low-Code/No-Code Security Risks
 
@@ -28,14 +12,6 @@
 - [LCNC-SEC-08: Data and Secret Handling Failures](/www-project-top-10-low-code-no-code-security-risks/content/en/LCNC-SEC-08-Data-and-Secret-Handling-Failures)
 - [LCNC-SEC-09: Asset Management Failures](/www-project-top-10-low-code-no-code-security-risks/content/en/LCNC-SEC-09-Asset-Management-Failures)
 - [LCNC-SEC-10: Security Logging and Monitoring Failures](/www-project-top-10-low-code-no-code-security-risks/content/en/LCNC-SEC-10-Security-Logging-and-Monitoring-Failures)
-
-### Social and Community
-
-[Twitter](https://twitter.com/OWASPNoCode)
-
-[Slack](https://owasp.slack.com/archives/C02C6RU6G10)
-
-[Email group](https://groups.google.com/g/owasp-no-code-low-code)
 
 ### Licensing
 

--- a/index.md
+++ b/index.md
@@ -28,16 +28,16 @@ The guide provides information about what are the most prominent security risks 
 
 ## The List
 
-1. [LCNC-SEC-01: Account Impersonation](https://github.com/OWASP/www-project-top-10-low-code-no-code-security-risks/blob/main/content/en/LCNC-SEC-01-Account-Impersonation.md)
-2. [LCNC-SEC-02: Authorization Misuse](https://github.com/OWASP/www-project-top-10-low-code-no-code-security-risks/blob/main/content/en/LCNC-SEC-02-Authorization-Misuse.md)
-3. [LCNC-SEC-03: Data Leakage and Unexpected Consequences](https://github.com/OWASP/www-project-top-10-low-code-no-code-security-risks/blob/main/content/en/LCNC-SEC-03-Data-Leakage-and-Unexpected-Consequences.md)
-4. [LCNC-SEC-04: Authentication and Secure Communication Failures](https://github.com/OWASP/www-project-top-10-low-code-no-code-security-risks/blob/main/content/en/LCNC-SEC-04-Authentication-and-Secure-Communication-Failures.md)
-5. [LCNC-SEC-05: Security Misconfiguration](https://github.com/OWASP/www-project-top-10-low-code-no-code-security-risks/blob/main/content/en/LCNC-SEC-05-Security-Misconfiguration.md)
-6. [LCNC-SEC-06: Injection Handling Failures](https://github.com/OWASP/www-project-top-10-low-code-no-code-security-risks/blob/main/content/en/LCNC-SEC-06-Injection-Handling-Failures.md)
-7. [LCNC-SEC-07: Vulnerable and Untrusted Components](https://github.com/OWASP/www-project-top-10-low-code-no-code-security-risks/blob/main/content/en/LCNC-SEC-07-Vulnerable-and-Untrusted-Components.md)
-8. [LCNC-SEC-08: Data and Secret Handling Failures](https://github.com/OWASP/www-project-top-10-low-code-no-code-security-risks/blob/main/content/en/LCNC-SEC-08-Data-and-Secret-Handling-Failures.md)
-9. [LCNC-SEC-09: Asset Management Failures](https://github.com/OWASP/www-project-top-10-low-code-no-code-security-risks/blob/main/content/en/LCNC-SEC-09-Asset-Management-Failures.md)
-10. [LCNC-SEC-10: Security Logging and Monitoring Failures](https://github.com/OWASP/www-project-top-10-low-code-no-code-security-risks/blob/main/content/en/LCNC-SEC-10-Security-Logging-and-Monitoring-Failures.md)
+1. [LCNC-SEC-01: Account Impersonation](content/en/LCNC-SEC-01-Account-Impersonation)
+2. [LCNC-SEC-02: Authorization Misuse](content/en/LCNC-SEC-02-Authorization-Misuse)
+3. [LCNC-SEC-03: Data Leakage and Unexpected Consequences](content/en/LCNC-SEC-03-Data-Leakage-and-Unexpected-Consequences)
+4. [LCNC-SEC-04: Authentication and Secure Communication Failures](content/en/LCNC-SEC-04-Authentication-and-Secure-Communication-Failures)
+5. [LCNC-SEC-05: Security Misconfiguration](content/en/LCNC-SEC-05-Security-Misconfiguration)
+6. [LCNC-SEC-06: Injection Handling Failures](content/en/LCNC-SEC-06-Injection-Handling-Failures)
+7. [LCNC-SEC-07: Vulnerable and Untrusted Components](content/en/LCNC-SEC-07-Vulnerable-and-Untrusted-Components)
+8. [LCNC-SEC-08: Data and Secret Handling Failures](content/en/LCNC-SEC-08-Data-and-Secret-Handling-Failures)
+9. [LCNC-SEC-09: Asset Management Failures](content/en/LCNC-SEC-09-Asset-Management-Failures)
+10. [LCNC-SEC-10: Security Logging and Monitoring Failures](content/en/LCNC-SEC-10-Security-Logging-and-Monitoring-Failures)
 
 
 ## Project Sponsors


### PR DESCRIPTION
Interesting project. One thing I found when looking thought the content on the OWASP website was been bounced between the website and github when just browsing was a little jarring.  

The changes in this PR make the navigation much more like [OWASP Top 10 CI/CD Security Risks](https://owasp.org/www-project-top-10-ci-cd-security-risks/) project. 

These changes are summarised in
1. Preferring the rendered content over GitHub source
2. Adding sidebar navigation to help move between each risk 

Example result with new nav highlighted in red
![image](https://user-images.githubusercontent.com/1075126/202909828-0bb3e772-90f9-4688-a9de-7d0b6b2700f1.png)
