### PR TITLE
Updating LCNC-SEC-02 with broad application scope

### DIFF
--- a/content/en/LCNC-SEC-02-Authorization-Misuse.md
+++ b/content/en/LCNC-SEC-02-Authorization-Misuse.md
@@ -13,7 +13,7 @@ title: "LCNC-SEC-02: Authorization Misuse"
 
 ## The Gist
 
-Connections are first-class objects in most no-code/low-code platforms. This means connections between applications, other users, or entire organizations. Applications can also be shared with users who should not have access to their underlying data.
+Connections are first-class objects in most no-code/low-code platforms. This means connections between applications, other users, or entire organizations. Applications can also be shared with users who should not have access to their underlying data. In addition, the application may have a broad authorization scope more than the use case demands.
 
 ## Description
 
@@ -26,6 +26,8 @@ Many no-code/low-code platforms abuse OAuth authorization flows by querying and 
 This allows business users to quickly set up connections without thinking about secrets or permissions; at the same time, connections are embedded with user identities that are difficult to monitor or revoke.
 Even though OAuth refresh tokens are designed to be short-lived, they are most frequently valid for a few months or even years. 
 Hence, a connection created by a business user in under a minute could persist in the no-code/low-code platform for an extended period and often get used by other users for different purposes than the original intention.
+
+An authorization scope controls the access to resources and assets of an organization. No-code/low-code platform application developers prefer broad authorization scope for their applications to make them as generic as possible. For organizations, this allows quick and easy setup of applications, which they can later use for other use cases without needing another application. The broad authorization scope does come at the cost of unnecessary risk of authorization misuse.
 
 ## Example Attack Scenarios
 
@@ -49,6 +51,10 @@ Admin connects an application to their source code management system (i.e., BitB
 The provisioned service or application account has unrestricted access to all repositories to enable seamless integration.
 Any internal user can abuse this connection to access restricted repositories they usually don't have access to.
 
+### Scenario #4
+
+A developer creates a simple application to submit forms from one platform to another.
+The application, however, is configured to require authorization to edit and delete form submissions when just creating form submissions should have been enough.
 
 ## How to Prevent
 
@@ -57,6 +63,7 @@ Any internal user can abuse this connection to access restricted repositories th
 - Monitor no-code/low-code platforms for over-shared connections.
 - Educate business users on the risks of connection sharing and its relation to credential sharing.
 - Explicitly refresh OAuth tokens on a regular basis by re-authenticating connections.
+- Carefully review the scope an application requires and adhere to the principle of least privilege.
 
 ## References
 


### PR DESCRIPTION
Thanks for the webinar today. It was informative.

I am a user of many no-code/low-code platforms and have found myself several times in a situation where the application has a broad authorization scope. I have updated the `content/en/LCNC-SEC-02-Authorization-Misuse.md` file with information about the broad application scope.