### PR TITLE
fix: restore proper aspect ratio on logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OWASP Low-Code/No-Code Top 10
 
-<a href="https://owasp.org/www-project-top-10-low-code-no-code-security-risks/"><img src="assets/images/owasp-lcnc-top10-logo.png" alt="OWASP Low-Code/No-Code Top 10" width="500" height="250" /></a>
+<a href="https://owasp.org/www-project-top-10-low-code-no-code-security-risks/"><img src="assets/images/owasp-lcnc-top10-logo.png" alt="OWASP Low-Code/No-Code Top 10" width="500"/></a>
 
 [![stars](https://img.shields.io/github/stars/OWASP/www-project-top-10-low-code-no-code-security-risks?icon=github&style=social)](https://github.com/OWASP/www-project-top-10-low-code-no-code-security-risks)
 [![twitter](https://img.shields.io/twitter/follow/OWASPNoCode?icon=twitter&style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=OWASPNoCode)

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ type: documentation
 pitch: The primary goal of the "OWASP Top 10 Low-Code/No-Code Security Risks" document is to provide assistance and education for organizations looking to adopt and develop Low-Code/No-Code applications. The guide provides information about what are the most prominent security risks for such applications, the challenges involved, and how to overcome them.
 
 ---
-<a href="https://owasp.org/www-project-top-10-low-code-no-code-security-risks/"><img src="assets/images/owasp-lcnc-top10-logo.png" alt="OWASP Low-Code/No-Code Top 10" width="500" height="250" /></a>
+<a href="https://owasp.org/www-project-top-10-low-code-no-code-security-risks/"><img src="assets/images/owasp-lcnc-top10-logo.png" alt="OWASP Low-Code/No-Code Top 10" width="500" /></a>
 
 [![stars](https://img.shields.io/github/stars/OWASP/www-project-top-10-low-code-no-code-security-risks?icon=github&style=social)](https://github.com/OWASP/www-project-top-10-low-code-no-code-security-risks)
 [![twitter](https://img.shields.io/twitter/follow/OWASPNoCode?icon=twitter&style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=OWASPNoCode)


### PR DESCRIPTION
The logo's aspect ratio is off because the width and height are both hard-coded. Only the width is needed.